### PR TITLE
Fix an issue where line breaks are ignored in the element about section

### DIFF
--- a/src/features/Element/MainContent.jsx
+++ b/src/features/Element/MainContent.jsx
@@ -273,7 +273,17 @@ export default function MainContent(props) {
             </div>
           </Box>
         ) : (
-          <Typography level="body-lg">{contents}</Typography>
+          <Typography
+            level="body-lg"
+            sx={{
+              pt: 2,
+              wordBreak: "break-word",
+              whiteSpace: "pre-wrap",
+              lineHeight: "150%",
+            }}
+          >
+            {contents}
+          </Typography>
         )}
       </Stack>
     );
@@ -388,7 +398,12 @@ export default function MainContent(props) {
       ) : (
         <Typography
           level="body-lg"
-          sx={{ pt: 2, wordBreak: "break-word", lineHeight: "150%" }}
+          sx={{
+            pt: 2,
+            wordBreak: "break-word",
+            whiteSpace: "pre-wrap",
+            lineHeight: "150%",
+          }}
         >
           {contents}
         </Typography>


### PR DESCRIPTION
Fix #295 
![Screenshot 2025-03-20 at 9 58 30 AM](https://github.com/user-attachments/assets/4df79926-3076-4fc0-86c9-c56cbb22c5f4)
