### PR TITLE
Spatial metadata autofill

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@mui/joy": "^5.0.0-beta.52",
     "@mui/material": "^6.4.8",
     "@uiw/react-markdown-preview": "^5.1.3",
-    "axios": "^1.8.4",
     "jdenticon": "^3.3.0",
     "jodit-react": "^5.2.15",
     "prop-types": "^15.8.1",

--- a/src/features/ElementSubmission/SpatialMetadataInfoCard.jsx
+++ b/src/features/ElementSubmission/SpatialMetadataInfoCard.jsx
@@ -1,13 +1,14 @@
 import React from "react";
 
 import Box from "@mui/joy/Box";
-import Button from "@mui/joy/Button";
 import Card from "@mui/joy/Card";
 import CardContent from "@mui/joy/CardContent";
 import Typography from "@mui/joy/Typography";
 import Stack from "@mui/joy/Stack";
 import Tooltip from "@mui/joy/Tooltip";
-import Divider from "@mui/joy/Divider";
+import Link from "@mui/joy/Link";
+import IconButton from "@mui/joy/IconButton";
+import CheckBoxIcon from "@mui/icons-material/CheckBox";
 
 const TEST_MODE = import.meta.env.VITE_TEST_MODE;
 
@@ -18,6 +19,7 @@ export default function SpatialMetadataInfoCard(props) {
   const category = props.category;
   const listIndex = props.listIndex;
   const setListIndex = props.setListIndex;
+  const selectedSpatialMetadataIndex = props.selectedSpatialMetadataIndex;
 
   const handleSelect = () => {
     TEST_MODE &&
@@ -26,19 +28,22 @@ export default function SpatialMetadataInfoCard(props) {
   };
 
   return (
-    <Box
-      sx={{
-        maxWidth: 300,
-        position: "relative",
-        overflow: { xs: "auto", sm: "initial" },
-      }}
-    >
+    <Tooltip title="Click to select this location" placement="top">
       <Card
-        variant="outlined"
-        orientation="horizontal"
+        variant={
+          selectedSpatialMetadataIndex === listIndex ? "soft" : "outlined"
+        }
+        color="primary"
         sx={{
-          maxWidth: "100%",
+          width: "100%",
+          height: "100%",
+          "--Card-radius": "15px",
+          "&:hover": {
+            borderColor: "theme.vars.palette.primary.outlinedHoverBorder",
+            transform: "translateY(-2px)",
+          },
         }}
+        onClick={handleSelect}
       >
         <CardContent sx={{ alignItems: "center" }}>
           <Box
@@ -49,32 +54,40 @@ export default function SpatialMetadataInfoCard(props) {
               "& > button": { flex: 1 },
             }}
           >
-            <Stack spacing={1} sx={{ alignItems: "flex-start" }}>
-              <Typography level="title-md">Option {listIndex + 1}</Typography>
-              <Typography level="body-sm">
-                <Typography level="title-sm">Name: </Typography>
-                {displayName}
-              </Typography>
-              <Typography level="body-sm">
-                <Typography level="title-sm">Address type: </Typography>
-                {addressType}
-              </Typography>
-              <Typography level="body-sm">
-                <Typography level="title-sm">Type: </Typography>
-                {type}
-              </Typography>
-              <Typography level="body-sm">
-                <Typography level="title-sm">Category: </Typography>
-                {category}
-              </Typography>
-              <Divider />
-              <Button variant="soft" color="success" onClick={handleSelect}>
-                Select
-              </Button>
+            <Stack direction="column" sx={{ justifyContent: "space-around" }}>
+              <Stack spacing={1} sx={{ alignItems: "flex-start" }}>
+                {/* Link component is to change cursor to hand when hovering over */}
+                <Link overlay underline="none">
+                  <Typography level="title-md">
+                    Location {listIndex + 1}
+                  </Typography>
+                  {selectedSpatialMetadataIndex === listIndex && (
+                    <IconButton size="sm" color="primary">
+                      <CheckBoxIcon />
+                    </IconButton>
+                  )}
+                </Link>
+                <Typography level="body-sm">
+                  <Typography level="title-sm">Name: </Typography>
+                  {displayName}
+                </Typography>
+                <Typography level="body-sm">
+                  <Typography level="title-sm">Address type: </Typography>
+                  {addressType}
+                </Typography>
+                <Typography level="body-sm">
+                  <Typography level="title-sm">Type: </Typography>
+                  {type}
+                </Typography>
+                <Typography level="body-sm">
+                  <Typography level="title-sm">Category: </Typography>
+                  {category}
+                </Typography>
+              </Stack>
             </Stack>
           </Box>
         </CardContent>
       </Card>
-    </Box>
+    </Tooltip>
   );
 }

--- a/src/features/ElementSubmission/SpatialMetadataInfoCard.jsx
+++ b/src/features/ElementSubmission/SpatialMetadataInfoCard.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+
+import Box from "@mui/joy/Box";
+import Button from "@mui/joy/Button";
+import Card from "@mui/joy/Card";
+import CardContent from "@mui/joy/CardContent";
+import Typography from "@mui/joy/Typography";
+import Stack from "@mui/joy/Stack";
+import Tooltip from "@mui/joy/Tooltip";
+import Divider from "@mui/joy/Divider";
+
+const TEST_MODE = import.meta.env.VITE_TEST_MODE;
+
+export default function SpatialMetadataInfoCard(props) {
+  const displayName = props.displayName;
+  const addressType = props.addressType;
+  const type = props.type;
+  const category = props.category;
+  const listIndex = props.listIndex;
+  const setListIndex = props.setListIndex;
+
+  const handleSelect = () => {
+    TEST_MODE &&
+      console.log("SpatialMetadataInfoCard: Selected option", listIndex + 1);
+    setListIndex(listIndex);
+  };
+
+  return (
+    <Box
+      sx={{
+        maxWidth: 300,
+        position: "relative",
+        overflow: { xs: "auto", sm: "initial" },
+      }}
+    >
+      <Card
+        variant="outlined"
+        orientation="horizontal"
+        sx={{
+          maxWidth: "100%",
+        }}
+      >
+        <CardContent sx={{ alignItems: "center" }}>
+          <Box
+            sx={{
+              p: 0.5,
+              display: "flex",
+              gap: 1.5,
+              "& > button": { flex: 1 },
+            }}
+          >
+            <Stack spacing={1} sx={{ alignItems: "flex-start" }}>
+              <Typography level="title-md">Option {listIndex + 1}</Typography>
+              <Typography level="body-sm">
+                <Typography level="title-sm">Name: </Typography>
+                {displayName}
+              </Typography>
+              <Typography level="body-sm">
+                <Typography level="title-sm">Address type: </Typography>
+                {addressType}
+              </Typography>
+              <Typography level="body-sm">
+                <Typography level="title-sm">Type: </Typography>
+                {type}
+              </Typography>
+              <Typography level="body-sm">
+                <Typography level="title-sm">Category: </Typography>
+                {category}
+              </Typography>
+              <Divider />
+              <Button variant="soft" color="success" onClick={handleSelect}>
+                Select
+              </Button>
+            </Stack>
+          </Box>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/src/features/ElementSubmission/SubmissionCard.jsx
+++ b/src/features/ElementSubmission/SubmissionCard.jsx
@@ -1043,6 +1043,21 @@ export default function SubmissionCard(props) {
                     </Button>
                   </Grid>
                 </Grid>
+                <FormHelperText>
+                  <Typography level="body-sm">
+                    To learn more about Crossref, the autofill API provider,
+                    please click&nbsp;
+                    <Link
+                      component={RouterLink}
+                      to={`https://www.crossref.org/`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      here
+                    </Link>
+                    .
+                  </Typography>
+                </FormHelperText>
                 {elementIdWithDuplicateDOI && (
                   <FormHelperText>
                     <Typography level="title-sm" color="danger">
@@ -1555,7 +1570,10 @@ export default function SubmissionCard(props) {
             </Typography>
             <FormControl sx={{ gridColumn: "1/-1", py: 0.5 }}>
               <FormLabel>
-                <SubmissionCardFieldTitle tooltipTitle="The location name for spatial metadata autofill, e.g., Chicago, Lake Michigan, a house address...">
+                <SubmissionCardFieldTitle
+                  tooltipTitle="Provide the location name for spatial metadata autofill. It can be a city, landmark, organization, or even a street address."
+                  tooltipContent={`Feature powered by Nominatim. Please note that the API may not return the correct result, or may return no result at all.`}
+                >
                   Enter the location name (only for spatial metadata autofill)
                 </SubmissionCardFieldTitle>
               </FormLabel>
@@ -1579,6 +1597,21 @@ export default function SubmissionCard(props) {
                   </Button>
                 </Grid>
               </Grid>
+              <FormHelperText>
+                <Typography level="body-sm">
+                  To learn more about Nominatim, the autofill API provider,
+                  please click&nbsp;
+                  <Link
+                    component={RouterLink}
+                    to={`https://nominatim.org/`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    here
+                  </Link>
+                  .
+                </Typography>
+              </FormHelperText>
             </FormControl>
             {spatialMetadataList?.length > 0 && (
               <Grid sx={{ gridColumn: "1/-1", py: 0.5 }}>

--- a/src/features/ElementSubmission/SubmissionCard.jsx
+++ b/src/features/ElementSubmission/SubmissionCard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, lazy, Suspense } from "react";
 import { useOutletContext, Link as RouterLink } from "react-router";
 
-import Grid from "@mui/joy/Grid";
+import Grid from "@mui/material/Grid2";
 import Card from "@mui/joy/Card";
 import AspectRatio from "@mui/joy/AspectRatio";
 import Select from "@mui/joy/Select";
@@ -326,8 +326,6 @@ export default function SubmissionCard(props) {
       setCentroid(
         `${selectedSpatialMetadata.lat}, ${selectedSpatialMetadata.lon}`
       );
-      setSelectedSpatialMetadataIndex(-1);
-      setSpatialMetadataList([]);
     }
   }, [selectedSpatialMetadataIndex, spatialMetadataList]);
 
@@ -531,20 +529,20 @@ export default function SubmissionCard(props) {
 
   // Autofill spatial metadata
   const handleAutofillSpatialMetadata = async () => {
+    setSelectedSpatialMetadataIndex(-1);
     if (!spatialDescription || spatialDescription === "") {
       alert("Please enter the spatial metadata first.");
       return;
     }
 
     const returnedList = await getSpatialMetadata(spatialDescription);
-    setSpatialMetadataList(returnedList);
-
     if (!returnedList || returnedList.length === 0) {
       alert(
         "The Nominatim API didn't return any spatial metadata. Please check the input or manually enter the spatial information in the fields below."
       );
       return;
     }
+    setSpatialMetadataList(returnedList);
   };
 
   const handleLicenseChange = (value) => {
@@ -1011,7 +1009,7 @@ export default function SubmissionCard(props) {
                   </SubmissionCardFieldTitle>
                 </FormLabel>
                 <Grid container spacing={2} sx={{ flexGrow: 1 }}>
-                  <Grid xs>
+                  <Grid size="grow">
                     {submissionType === "initial" ? (
                       <Input
                         required
@@ -1023,7 +1021,7 @@ export default function SubmissionCard(props) {
                       <Typography>{publicationDOI}</Typography>
                     )}
                   </Grid>
-                  <Grid xs="auto">
+                  <Grid size="auto">
                     <Button
                       variant="outlined"
                       onClick={handleAutofillPublicationInfo}
@@ -1549,7 +1547,7 @@ export default function SubmissionCard(props) {
                 </SubmissionCardFieldTitle>
               </FormLabel>
               <Grid container spacing={2} sx={{ flexGrow: 1 }}>
-                <Grid xs>
+                <Grid size="grow">
                   <Input
                     placeholder="Examples: Chicago; Lake Michigan; 123 Main St, City, State..."
                     value={spatialDescription}
@@ -1558,7 +1556,7 @@ export default function SubmissionCard(props) {
                     }
                   />
                 </Grid>
-                <Grid xs="auto">
+                <Grid size="auto">
                   <Button
                     variant="outlined"
                     onClick={handleAutofillSpatialMetadata}
@@ -1568,29 +1566,37 @@ export default function SubmissionCard(props) {
                 </Grid>
               </Grid>
             </FormControl>
-            {spatialMetadataList.length > 0 && (
+            {spatialMetadataList?.length > 0 && (
               <Grid sx={{ gridColumn: "1/-1", py: 0.5 }}>
-                <Typography level="title-sm">
-                  We have found one or more matching locations. Please select
-                  one for metadata autofill:
+                <Typography level="title-sm" sx={{ pb: 1 }}>
+                  We have found {spatialMetadataList.length} matching location
+                  {spatialMetadataList.length > 1 && "s"}. Please click{" "}
+                  {spatialMetadataList.length > 1 && "one"} to autofill spatial
+                  metadata:
                 </Typography>
-                <Stack
-                  spacing={1}
-                  direction="width"
-                  useFlexGap
-                  sx={{ flexWrap: "wrap", width: "100%" }}
+                <Grid
+                  container
+                  spacing={3}
+                  columns={12}
+                  sx={{ flexGrow: 1 }}
+                  justifyContent="flex-start"
                 >
                   {spatialMetadataList?.map((spatialMetadata, index) => (
-                    <SpatialMetadataInfoCard
-                      displayName={spatialMetadata.display_name}
-                      addressType={spatialMetadata.addresstype}
-                      type={spatialMetadata.type}
-                      category={spatialMetadata.category}
-                      listIndex={index}
-                      setListIndex={setSelectedSpatialMetadataIndex}
-                    />
+                    <Grid key={index} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+                      <SpatialMetadataInfoCard
+                        displayName={spatialMetadata.display_name}
+                        addressType={spatialMetadata.addresstype}
+                        type={spatialMetadata.type}
+                        category={spatialMetadata.category}
+                        listIndex={index}
+                        setListIndex={setSelectedSpatialMetadataIndex}
+                        selectedSpatialMetadataIndex={
+                          selectedSpatialMetadataIndex
+                        }
+                      />
+                    </Grid>
                   ))}
-                </Stack>
+                </Grid>
               </Grid>
             )}
 
@@ -1634,8 +1640,8 @@ export default function SubmissionCard(props) {
                 spacing={2}
                 sx={{ flexGrow: 1, alignItems: "center" }}
               >
-                <Grid xs="auto">{"ENVELOPE("}</Grid>
-                <Grid xs>
+                <Grid size="auto">{"ENVELOPE("}</Grid>
+                <Grid size="grow">
                   <Input
                     placeholder="-111.1, -104.0, 45.0, 40.9"
                     value={boundingBox}
@@ -1644,7 +1650,7 @@ export default function SubmissionCard(props) {
                     }
                   />
                 </Grid>
-                <Grid xs="auto">{")"}</Grid>
+                <Grid size="auto">{")"}</Grid>
               </Grid>
             </FormControl>
             <FormControl sx={{ gridColumn: "1/-1", py: 0.5 }}>

--- a/src/features/ElementSubmission/SubmissionCard.jsx
+++ b/src/features/ElementSubmission/SubmissionCard.jsx
@@ -151,6 +151,10 @@ export default function SubmissionCard(props) {
   const [notebookGitHubUrlError, setNotebookGitHubUrlError] = useState(false);
 
   const [publicationDOI, setPublicationDOI] = useState("");
+  const [
+    publicationMetadataAutofillLoading,
+    setPublicationMetadataAutofillLoading,
+  ] = useState(false);
   const [elementIdWithDuplicateDOI, setElementIdWithDuplicateDOI] = useState();
 
   const [mapIframeLink, setMapIframeLink] = useState("");
@@ -163,6 +167,8 @@ export default function SubmissionCard(props) {
   const [spatialMetadataList, setSpatialMetadataList] = useState([]);
   const [selectedSpatialMetadataIndex, setSelectedSpatialMetadataIndex] =
     useState(-1);
+  const [spatialMetadataAutofillLoading, setSpatialMetadataAutofillLoading] =
+    useState(false);
   const [spatialDescription, setSpatialDescription] = useState("");
   const [spatialCoverage, setSpatialCoverage] = useState([]);
   const [geometry, setGeometry] = useState("");
@@ -456,7 +462,9 @@ export default function SubmissionCard(props) {
       return;
     }
 
+    setPublicationMetadataAutofillLoading(true);
     const metadataDOI = await getMetadataByDOI(publicationDOI);
+    setPublicationMetadataAutofillLoading(false);
     TEST_MODE && console.log("pub metadata", metadataDOI);
 
     if (!metadataDOI || metadataDOI === "") {
@@ -530,12 +538,16 @@ export default function SubmissionCard(props) {
   // Autofill spatial metadata
   const handleAutofillSpatialMetadata = async () => {
     setSelectedSpatialMetadataIndex(-1);
+    setSpatialMetadataList([]);
     if (!spatialDescription || spatialDescription === "") {
       alert("Please enter the spatial metadata first.");
       return;
     }
 
+    setSpatialMetadataAutofillLoading(true);
     const returnedList = await getSpatialMetadata(spatialDescription);
+    setSpatialMetadataAutofillLoading(false);
+
     if (!returnedList || returnedList.length === 0) {
       alert(
         "The Nominatim API didn't return any spatial metadata. Please check the input or manually enter the spatial information in the fields below."
@@ -1024,6 +1036,7 @@ export default function SubmissionCard(props) {
                   <Grid size="auto">
                     <Button
                       variant="outlined"
+                      loading={publicationMetadataAutofillLoading}
                       onClick={handleAutofillPublicationInfo}
                     >
                       Autofill metadata
@@ -1559,6 +1572,7 @@ export default function SubmissionCard(props) {
                 <Grid size="auto">
                   <Button
                     variant="outlined"
+                    loading={spatialMetadataAutofillLoading}
                     onClick={handleAutofillSpatialMetadata}
                   >
                     Autofill metadata

--- a/src/features/ElementSubmission/SubmissionCard.jsx
+++ b/src/features/ElementSubmission/SubmissionCard.jsx
@@ -65,13 +65,15 @@ import {
 import {
   fetchSingleElementDetails,
   fetchAllTitlesByElementType,
-  getMetadataByDOI,
   duplicateDOIExists,
   fetchSinglePrivateElementDetails,
 } from "../../utils/DataRetrieval";
 import { printListWithDelimiter } from "../../helpers/helper";
 
-import { getSpatialMetadata } from "../../utils/ExternalDataRetrieval";
+import {
+  getSpatialMetadata,
+  getPublicationMetadata,
+} from "../../utils/ExternalDataRetrieval";
 
 const USER_BACKEND_URL = import.meta.env.VITE_DATABASE_BACKEND_URL;
 const TEST_MODE = import.meta.env.VITE_TEST_MODE;
@@ -463,7 +465,7 @@ export default function SubmissionCard(props) {
     }
 
     setPublicationMetadataAutofillLoading(true);
-    const metadataDOI = await getMetadataByDOI(publicationDOI);
+    const metadataDOI = await getPublicationMetadata(publicationDOI);
     setPublicationMetadataAutofillLoading(false);
     TEST_MODE && console.log("pub metadata", metadataDOI);
 
@@ -547,6 +549,13 @@ export default function SubmissionCard(props) {
     setSpatialMetadataAutofillLoading(true);
     const returnedList = await getSpatialMetadata(spatialDescription);
     setSpatialMetadataAutofillLoading(false);
+
+    if (returnedList === "ERROR") {
+      alert(
+        "The Nominatim API is not available at this moment. Please try again later or manually enter the spatial metadata."
+      );
+      return;
+    }
 
     if (!returnedList || returnedList.length === 0) {
       alert(

--- a/src/utils/DataRetrieval.jsx
+++ b/src/utils/DataRetrieval.jsx
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { fetchWithAuth } from "./FetcherWithJWT";
 import { sendBugToSlack } from "./AutomaticBugReporting";
 
@@ -156,34 +155,6 @@ export async function fetchAllTitlesByElementType(elementType) {
     throw new Error("Failed to fetch titles");
   }
   return response.json();
-}
-
-/**
- * Fetches publication metadata via Crossref
- *
- * @async
- * @function getMetadataByDOI
- * @param {string} doi - The DOI of the publication
- * @returns {Promise<Array<string>>} A promise that contains the metadata of the publication
- * @throws {Error} Throws an error if the fetch operation fails.
- */
-export async function getMetadataByDOI(doi) {
-  const encodedDOI = encodeURIComponent(doi);
-  try {
-    // Construct the CrossRef API URL
-    const url = `https://api.crossref.org/works/${encodedDOI}`;
-
-    // Make the HTTP request to the CrossRef API
-    const response = await axios.get(url);
-
-    // Extract metadata from the response
-    const metadata = response.data.message;
-
-    return metadata;
-  } catch (error) {
-    console.warn("Error fetching metadata:", error);
-    return "Publication not found";
-  }
 }
 
 /**

--- a/src/utils/ExternalDataRetrieval.jsx
+++ b/src/utils/ExternalDataRetrieval.jsx
@@ -1,6 +1,40 @@
 const TEST_MODE = import.meta.env.VITE_TEST_MODE;
 
 /**
+ * Fetches publication metadata via Crossref
+ *
+ * @async
+ * @function getPublicationMetadata
+ * @param {string} doi - The DOI of the publication
+ * @returns {Promise<Array<string>>} A promise that contains the metadata of the publication
+ * @throws {Error} Throws an error if the fetch operation fails.
+ */
+export async function getPublicationMetadata(doi) {
+  const encodedDOI = encodeURIComponent(doi);
+  try {
+    // Construct the CrossRef API URL
+    const apiCall = `https://api.crossref.org/works/${encodedDOI}`;
+    const response = await fetch(apiCall);
+
+    // Make the HTTP request to the CrossRef API
+    if (!response.ok) {
+      throw new Error(
+        `Error fetching publication metadata: ${response.statusText}`
+      );
+    }
+
+    // Extract metadata from the response
+    const metadata = await response.json();
+    TEST_MODE && console.log("Returned publication metadata", metadata);
+
+    return metadata?.message;
+  } catch (error) {
+    console.warn("Error fetching metadata:", error);
+    return "Publication not found";
+  }
+}
+
+/**
  * Retrieve spatial metadata.
  *
  * @async
@@ -11,20 +45,25 @@ const TEST_MODE = import.meta.env.VITE_TEST_MODE;
  */
 export async function getSpatialMetadata(location) {
   const encodedLocation = encodeURIComponent(location);
-  const apiCall = `https://nominatim.openstreetmap.org/search?q=${encodedLocation}&format=jsonv2&polygon_text=true&polygon_threshold=0.001`;
-  const response = await fetch(apiCall);
+  try {
+    const apiCall = `https://nominatim.openstreetmap.org/search?q=${encodedLocation}&format=jsonv2&polygon_text=true&polygon_threshold=0.001`;
+    const response = await fetch(apiCall);
 
-  if (!response.ok) {
-    throw new Error(
-      `Error autofilling the spatial metadata: ${response.statusText}`
-    );
+    if (!response.ok) {
+      throw new Error(
+        `Error fetching the spatial metadata: ${response.statusText}`
+      );
+    }
+
+    const data = await response.json();
+    TEST_MODE && console.log("Returned spatial metadata", data);
+    if (!data || data.length === 0) {
+      return null;
+    }
+
+    return data;
+  } catch (error) {
+    console.warn("Error fetching spatial metadata: ", error.message);
+    return "ERROR";
   }
-
-  const data = await response.json();
-  TEST_MODE && console.log("Returned spatial metadata", data);
-  if (!data || data.length === 0) {
-    return null;
-  }
-
-  return data;
 }

--- a/src/utils/ExternalDataRetrieval.jsx
+++ b/src/utils/ExternalDataRetrieval.jsx
@@ -1,0 +1,31 @@
+const TEST_MODE = import.meta.env.VITE_TEST_MODE;
+
+/**
+ * Retrieve spatial metadata.
+ *
+ * @async
+ * @function getSpatialMetadata
+ * @param {string} location - Location users input
+ * @returns {Promise<Object>} A promise that resolves to the JSON response containing the spatial metadata.
+ * @throws {Error} Throws an error if the fetch operation fails.
+ */
+export async function getSpatialMetadata(location) {
+  const encodedLocation = encodeURIComponent(location);
+  const apiCall = `https://nominatim.openstreetmap.org/search?q=${encodedLocation}&format=jsonv2&polygon_text=true&polygon_threshold=0.001`;
+  const response = await fetch(apiCall);
+
+  if (!response.ok) {
+    throw new Error(
+      `Error autofilling the spatial metadata: ${response.statusText}`
+    );
+  }
+
+  const data = await response.json();
+  TEST_MODE && console.log("Returned spatial metadata", data);
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  // Only return the highest ranked result
+  return data[0];
+}

--- a/src/utils/ExternalDataRetrieval.jsx
+++ b/src/utils/ExternalDataRetrieval.jsx
@@ -26,6 +26,5 @@ export async function getSpatialMetadata(location) {
     return null;
   }
 
-  // Only return the highest ranked result
-  return data[0];
+  return data;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,24 +1314,10 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
 autobind-decorator@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.4.0.tgz#ea9e1c98708cf3b5b356f7cf9f10f265ff18239c"
   integrity sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==
-
-axios@^1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
-  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
@@ -1507,13 +1493,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
 
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
@@ -1728,11 +1707,6 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.0:
   version "2.0.3"
@@ -2038,20 +2012,6 @@ flatted@^3.2.9:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
-
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
-
-form-data@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
-  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 format@^0.2.0:
   version "0.2.2"
@@ -3143,18 +3103,6 @@ micromark@^4.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
-
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -3397,11 +3345,6 @@ property-information@^6.0.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.5.0.tgz#6212fbb52ba757e92ef4fb9d657563b933b7ffec"
   integrity sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
## Changes made
- Allow users to simply enter a location name, and a Nominatim API will autofill the spatial metadata without manual inputs from the user. #331 
- Simplify Crossref API handling
- Replace Axios with fetch
