### PR TITLE
Allow localhost to access secured endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ VITE_USE_DEMO_USER=
 # Add your userid and preferred role to test the element grid for the user profile page
 VITE_DEMO_USERID=
 VITE_DEMO_USER_ROLE=
+# API key used to access the secured endpoints only in localhost
+VITE_LOCALHOST_API_KEY=
 
 # When this is true, print out the console.log, otherwise leave it EMPTY
 VITE_TEST_MODE=

--- a/src/utils/FetcherWithJWT.jsx
+++ b/src/utils/FetcherWithJWT.jsx
@@ -2,8 +2,23 @@ import { userLogout } from "./UserManager";
 
 const BACKEND_URL_PORT = import.meta.env.VITE_DATABASE_BACKEND_URL;
 const TEST_MODE = import.meta.env.VITE_TEST_MODE;
+const ENV = import.meta.env.VITE_ENV;
+const LOCALHOST_API_KEY = import.meta.env.VITE_LOCALHOST_API_KEY;
 
 export async function fetchWithAuth(url, options = {}) {
+  if (ENV === "localhost" && LOCALHOST_API_KEY) {
+    TEST_MODE && console.log("By passing JWT for localhost", url, options);
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        "JWT-API-KEY": { LOCALHOST_API_KEY },
+      },
+    });
+
+    return res;
+  }
+
+  TEST_MODE && console.log("Fetch with JWT", url, options);
   let res = await fetch(url, {
     ...options,
     credentials: "include", // Ensure cookies are sent with the request

--- a/src/utils/FetcherWithJWT.jsx
+++ b/src/utils/FetcherWithJWT.jsx
@@ -11,7 +11,7 @@ export async function fetchWithAuth(url, options = {}) {
     const res = await fetch(url, {
       ...options,
       headers: {
-        "JWT-API-KEY": { LOCALHOST_API_KEY },
+        "JWT-API-KEY": LOCALHOST_API_KEY,
       },
     });
 

--- a/src/utils/FetcherWithJWT.jsx
+++ b/src/utils/FetcherWithJWT.jsx
@@ -6,6 +6,7 @@ const ENV = import.meta.env.VITE_ENV;
 const LOCALHOST_API_KEY = import.meta.env.VITE_LOCALHOST_API_KEY;
 
 export async function fetchWithAuth(url, options = {}) {
+  // When the environment is lcoalhost with correct API key, by pass JWT...
   if (ENV === "localhost" && LOCALHOST_API_KEY) {
     TEST_MODE && console.log("By passing JWT for localhost", url, options);
     const res = await fetch(url, {


### PR DESCRIPTION
Allow localhost to access secured endpoints via an API key.
