### PR TITLE
Add reverse proxy to Nginx to host the auth backend on the same port as the React frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@
 VITE_WEBSITE_TITLE=
 # The type of environment. E.g. prod, dev, localhost...
 VITE_ENV=
+# Server name. E.g., localhost
+VITE_SERVER_NAME=
 # Suffix for all cookies.
 # WARNING: this has to be the same as COOKIE_SUFFIX in the authentication backend
 VITE_COOKIE_SUFFIX=

--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,6 @@
 VITE_WEBSITE_TITLE=
 # The type of environment. E.g. prod, dev, localhost...
 VITE_ENV=
-# Server name. E.g., localhost
-VITE_SERVER_NAME=
 # Suffix for all cookies.
 # WARNING: this has to be the same as COOKIE_SUFFIX in the authentication backend
 VITE_COOKIE_SUFFIX=

--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,8 @@ VITE_COOKIE_SUFFIX=
 
 # The URL of the React frontend. Usually the domain name or "localhost"
 VITE_REACT_FRONTEND_URL=
-# The URL of the Mini backend for CILogon
-VITE_EXPRESS_BACKEND_URL=
+# The URL of the authentication backend for CILogon
+VITE_AUTH_BACKEND_URL=
 # The URL of the database
 VITE_DATABASE_BACKEND_URL=
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -16,7 +16,7 @@ env:
   VITE_TEST_MODE: true
   VITE_DO_NOT_USE_LLM_ENDPOINT: true
   VITE_REACT_FRONTEND_URL: https://localhost
-  VITE_EXPRESS_BACKEND_URL: https://localhost:8443
+  VITE_AUTH_BACKEND_URL: https://localhost
   VITE_DATABASE_BACKEND_URL: https://backend-dev.i-guide.io:3500
   VITE_JUPYTER_TUTORIAL_EID: ${{secrets.VITE_JUPYTER_TUTORIAL_EID}}
 
@@ -24,14 +24,14 @@ env:
   VITE_GA_MEASUREMENT_ID: ${{secrets.VITE_GA_MEASUREMENT_ID}}
 
   REACT_FRONTEND_URL: https://localhost
-  EXPRESS_BACKEND_URL: https://localhost:8443
+  EXPRESS_BACKEND_URL: https://localhost
   REACT_DATABASE_BACKEND_URL: https://backend-dev.i-guide.io:3500
 
   REACT_APP_AUTH_URL: https://cilogon.org
   REACT_APP_AUTH_DISCOVERY_URL: https://cilogon.org/.well-known/openid-configuration
   REACT_APP_IDENTITY_CLIENT_ID: cilogon:/client_id/6
   REACT_APP_IDENTITY_CLIENT_SECRET: ${{secrets.REACT_APP_IDENTITY_CLIENT_SECRET}}
-  REACT_APP_REDIRECT_URL: https://localhost:8443/cilogon-callback
+  REACT_APP_REDIRECT_URL: https://localhost/auth/callback/cilogon
   REACT_APP_LOGOFF_REDIRECT_URL: localhost
 
   JWT_ACCESS_TOKEN_SECRET: ${{secrets.JWT_ACCESS_TOKEN_SECRET}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.19-alpine AS build
 WORKDIR /app
-COPY package*.json ./
+COPY package.json yarn.lock ./
 RUN yarn install
 COPY . .
 RUN yarn build
@@ -14,5 +14,5 @@ COPY ./nginx-config/nginx.conf /etc/nginx/conf.d/default.conf
 COPY ./nginx-config/fullchain.pem /etc/nginx/ssl/fullchain.pem
 COPY ./nginx-config/privkey.pem /etc/nginx/ssl/privkey.pem
 COPY ./nginx-config/ip-list.d/ip-list*.conf /etc/nginx/
-EXPOSE 80 443
+
 CMD ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -5,66 +5,74 @@
 I-GUIDE Platform Frontend is the gateway to the I-GUIDE infrastructure. This web application shows users all the elements our contributors uploaded. One of the highlights of this app is that it focuses on building a network of related elements which makes it easier for users to explore more relevant contents.
 
 ## Project Status
+
 This project is currently under development.
 
 ## Installation
+
 ### Clone the repo from GitHub:
+
 ```bash
 git clone https://github.com/I-GUIDE/iguide-ue-frontend.git
 ```
 
-
 ### Register CILogon for SSO login
+
 CILogon website: https://www.cilogon.org/oidc
 
 CILogon client registration: https://cilogon.org/oauth2/register
 
 > [!TIP]
-> When you add callback URLs in the form, remember to add http://localhost:3000/cilogon-callback and https://localhost:8443/cilogon-callback. With those endpoints, you will find it easier to test CILogon on your localhost environment.
-
+> When you add callback URLs in the form, remember to add https://localhost/auth/callback/cilogon. With those endpoints, you will find it easier to test CILogon on your localhost environment.
 
 ### Set up the main and CILogon mini backend .env files:
+
 ```bash
 cp .env.example .env
 cp cilogon/.env.example cilogon cilogon/.env
 ```
+
 Complete both .env files by following the in-line comments.
 
-
 ### Set up SSL certificate:
+
 If you are running this app on a localhost environment, it is recommended to have a set of self-signed SSL certificates. You could follow this link to generate the .pem files. After getting fullchain.pem and privkey.pem, put them in both ./nginx-config and ./cilogon/credentials. You could visit ./Dockerfile and ./cilogon/auth_server.js to make sure their paths are correct.
 
 In the Dockerfile:
+
 ```Dockerfile
 COPY ./nginx-config/fullchain.pem /etc/nginx/ssl/fullchain.pem
 COPY ./nginx-config/privkey.pem /etc/nginx/ssl/privkey.pem
 ```
 
 In ./cilogon/auth_server.js:
+
 ```js
 const credentials = {
-    key: fs.readFileSync('credentials/privkey.pem'),
-    cert: fs.readFileSync('credentials/fullchain.pem')
+  key: fs.readFileSync("credentials/privkey.pem"),
+  cert: fs.readFileSync("credentials/fullchain.pem"),
 };
 ```
 
-
 ### Run the development server:
+
 ```bash
 yarn dev
 ```
+
 Open http://localhost:80 or other URL enabled by Vite to view it in your browser. The page will automatically reload when you make changes.
+
 > [!TIP]
 > This command won't enable HTTPS and is not ideal for testing CILogon.
 
-
 ### Run the production server:
+
 ```bash
 yarn build
 ```
 
-
 ### Use docker-compose:
+
 ```bash
 docker-compose up -d --build
 ```

--- a/cilogon/Dockerfile
+++ b/cilogon/Dockerfile
@@ -2,16 +2,16 @@
 FROM node:20.19-slim
 
 # Setting up the work directory
-WORKDIR /auth
+WORKDIR /app
 
-# Copying all the files in our project
-COPY . .
+# Copying files for yarn install
+COPY package.json yarn.lock ./
 
 # Installing dependencies
 RUN yarn install
 
-# Starting our application
-CMD [ "npx", "nodemon", "-r", "dotenv/config", "auth_server.js" ]
+# Copying all the files in our project
+COPY . .
 
-# Exposing server port
-EXPOSE 3000 8443
+# Starting our application
+CMD [ "node", "--watch", "auth_server.js" ]

--- a/cilogon/auth_server.js
+++ b/cilogon/auth_server.js
@@ -95,5 +95,5 @@ Issuer.discover(DISCOVERY_URL).then(function (oidcIssuer) {
 
 const httpServer = http.createServer(app);
 httpServer.listen(3000, "0.0.0.0", () => {
-  console.log("Authentication server running on port 3000")
+  logger.info("Authentication server running on port 3000");
 });

--- a/cilogon/auth_server.js
+++ b/cilogon/auth_server.js
@@ -6,17 +6,9 @@ const helmet = require('helmet');
 const passport = require('passport')
 const authRoute = require('./routes')
 const http = require("http");
-const https = require('https');
-const router = require("express").Router();
-const fs = require('fs');
 require('dotenv').config();
 const { Issuer, Strategy } = require('openid-client');
 const { logger, httpLogger } = require("./logger.js");
-
-const credentials = {
-  key: fs.readFileSync('credentials/privkey.pem'),
-  cert: fs.readFileSync('credentials/fullchain.pem')
-};
 
 // React frontend URL
 const FRONTEND_URL = process.env.REACT_FRONTEND_URL;
@@ -101,13 +93,7 @@ Issuer.discover(DISCOVERY_URL).then(function (oidcIssuer) {
   );
 });
 
-// const httpServer = http.createServer(app);
-const httpsServer = https.createServer(credentials, app);
-
-// httpServer.listen(80, () => {
-//   console.log(`Http Server Running on port 80`)
-// });
-
-httpsServer.listen(8443, () => {
-  logger.info("HTTPS authentication server running on port 8443")
+const httpServer = http.createServer(app);
+httpServer.listen(3000, "0.0.0.0", () => {
+  console.log("Authentication server running on port 3000")
 });

--- a/cilogon/logger.js
+++ b/cilogon/logger.js
@@ -1,6 +1,7 @@
 // logger.js
 const pino = require('pino');
 const pinoHttp = require('pino-http');
+require('dotenv').config();
 
 // Get current timestamp for the logging structure
 const currentTime = new Date();

--- a/cilogon/routes.js
+++ b/cilogon/routes.js
@@ -193,10 +193,10 @@ router.get("/callback/cilogon", async (req, res, next) => {
         message: err,
         user: user
       });
-      return res.redirect(`/error/cilogon`);
+      return res.redirect(`/auth/error/cilogon`);
     }
     if (!user) {
-      return res.redirect(`/error/nouser`);
+      return res.redirect(`/auth/error/nouser`);
     }
     req.logIn(user, async function (err) {
       if (err) {
@@ -205,7 +205,7 @@ router.get("/callback/cilogon", async (req, res, next) => {
           message: err,
           user: user
         });
-        return res.redirect(`/error/other`);
+        return res.redirect(`/auth/error/other`);
       }
 
       const openId = user.sub;
@@ -242,7 +242,7 @@ router.get("/callback/cilogon", async (req, res, next) => {
 
       // If role doesn't exist or returns ERROR, redirect users to the database error page
       if (!role || role === "ERROR") {
-        return res.redirect(`/error/database`);
+        return res.redirect(`/auth/error/database`);
       }
 
       // Generate JWT token with role

--- a/cilogon/routes.js
+++ b/cilogon/routes.js
@@ -410,6 +410,10 @@ router.get("/error/database", (req, res) => {
     or visit ${FRONTEND_URL}/contact-us to access our help page. We're here to help and look forward to resolving this matter for you.</p>`);
 });
 
+router.get('/health', (req, res) => {
+  res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, path.join(__dirname, "./uploads/"));

--- a/cilogon/routes.js
+++ b/cilogon/routes.js
@@ -181,7 +181,7 @@ router.get(
   })
 );
 
-router.get("/cilogon-callback", async (req, res, next) => {
+router.get("/callback/cilogon", async (req, res, next) => {
   // Retrieve the redirectURL from session, and then destory the session variable
   const redirectFullURL = req.session.redirectFullURL || `${FRONTEND_URL}/user-profile`;
   delete req.session.redirectFullURL;

--- a/cilogon/routes.js
+++ b/cilogon/routes.js
@@ -6,14 +6,12 @@ const multer = require("multer");
 const { createReadStream, unlinkSync, existsSync } = require("fs");
 const { WebClient } = require("@slack/web-api");
 const path = require("path");
-const dotenv = require("dotenv");
+require('dotenv').config();
 const fetch = (...args) =>
   import("node-fetch").then(({ default: fetch }) => fetch(...args));
 
 const { logger } = require("./logger.js");
 const { addUser, checkUser } = require("./user_management.js");
-
-dotenv.config();
 
 const router = express.Router();
 

--- a/cilogon/user_management.js
+++ b/cilogon/user_management.js
@@ -1,4 +1,5 @@
 const { logger } = require("./logger.js");
+require('dotenv').config();
 
 const AUTH_API_KEY = process.env.AUTH_API_KEY;
 const USER_BACKEND_URL = process.env.REACT_DATABASE_BACKEND_URL;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,25 @@
 services:
   app:
     image: iguide-ue-frontend-${VITE_ENV}
+    container_name: iguide-ue-react-nginx-${VITE_ENV}
     build:
       context: .
       dockerfile: Dockerfile
     ports:
       - "80:80"
       - "443:443"
+    depends_on:
+      - auth
     restart: always
 
   auth:
     image: iguide-ue-auth-${VITE_ENV}
+    container_name: iguide-ue-auth-${VITE_ENV}
     volumes:
       - ./cilogon/logs:/app/logs
     build:
       context: ./cilogon/.
       dockerfile: Dockerfile
-    ports:
-      - "3000:3000"
-      - "8443:8443"
+    expose:
+      - "3000"
     restart: always

--- a/nginx-config/nginx.conf
+++ b/nginx-config/nginx.conf
@@ -1,22 +1,39 @@
 # Redirect HTTP to HTTPS
 server {
-    listen 80;
-    server_name dev.i-guide.io;
-    return 301 https://$host$request_uri;
+  listen 80;
+  server_name dev.i-guide.io;
+  return 301 https://$host$request_uri;
 }
+
 # HTTPS server
 server {
-    gzip_static on;
-    gzip_proxied any;
-    listen 443 ssl;
-    server_name dev.i-guide.io;
-    ssl_certificate /etc/nginx/ssl/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
-    location / {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        try_files $uri $uri/ /index.html;
+  listen 443 ssl;
+	server_name dev.i-guide.io;
 
-        include /etc/nginx/ip-list*.conf;
-    }
+	ssl_certificate /etc/nginx/ssl/fullchain.pem;
+	ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+	# Serve React frontend
+	location / {
+		root /usr/share/nginx/html;
+		index index.html;
+		try_files $uri $uri/ /index.html;
+
+		include /etc/nginx/ip-list*.conf;
+	}
+
+	# Proxy API calls to the auth backend
+	location /auth/ {
+		# Proxy: auth container port 3000
+    proxy_pass http://auth:3000/;
+    proxy_http_version 1.1;
+
+    # forward headers
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_redirect off;
+  }
 }

--- a/src/components/Sitemap.jsx
+++ b/src/components/Sitemap.jsx
@@ -22,7 +22,7 @@ import usePageTitle from "../hooks/usePageTitle";
 import { NO_HEADER_BODY_HEIGHT } from "../configs/VarConfigs";
 import { PERMISSIONS } from "../configs/Permissions";
 
-const AUTH_BACKEND_URL = import.meta.env.VITE_EXPRESS_BACKEND_URL;
+const AUTH_BACKEND_URL = import.meta.env.VITE_AUTH_BACKEND_URL;
 
 function groupRoutesByCategory(routes, isAuthenticated, localUserInfo) {
   const items = {};
@@ -48,7 +48,7 @@ function groupRoutesByCategory(routes, isAuthenticated, localUserInfo) {
     if (!isAuthenticated) {
       items["Authentication"] = [
         {
-          path: `${AUTH_BACKEND_URL}/login`,
+          path: `${AUTH_BACKEND_URL}/auth/login`,
           label: "Login",
           category: "User login",
         },

--- a/src/routes/ContactUs.jsx
+++ b/src/routes/ContactUs.jsx
@@ -33,7 +33,7 @@ import usePageTitle from "../hooks/usePageTitle";
 import { sendMessageToSlack } from "../utils/AutomaticBugReporting";
 import { useAlertModal } from "../utils/AlertModalProvider";
 
-const VITE_EXPRESS_BACKEND_URL = import.meta.env.VITE_EXPRESS_BACKEND_URL;
+const AUTH_BACKEND_URL = import.meta.env.VITE_AUTH_BACKEND_URL;
 const TEST_MODE = import.meta.env.VITE_TEST_MODE;
 const VITE_GOOGLE_RECAPTCHA_SITE_KEY = import.meta.env
   .VITE_GOOGLE_RECAPTCHA_SITE_KEY;
@@ -181,7 +181,7 @@ export default function ContactUs() {
     }
     formData.append("contactDetails", JSON.stringify(contactDetails));
 
-    const res = await fetch(`${VITE_EXPRESS_BACKEND_URL}/upload-to-slack`, {
+    const res = await fetch(`${AUTH_BACKEND_URL}/auth/upload-to-slack`, {
       method: "POST",
       body: formData,
     });
@@ -206,7 +206,7 @@ export default function ContactUs() {
       return;
     } else {
       const res = await fetch(
-        `${VITE_EXPRESS_BACKEND_URL}/recaptcha-verification`,
+        `${AUTH_BACKEND_URL}/auth/recaptcha-verification`,
         {
           method: "POST",
           body: JSON.stringify({ recaptchaToken }),

--- a/src/utils/UserManager.jsx
+++ b/src/utils/UserManager.jsx
@@ -2,7 +2,7 @@ import { fetchWithAuth, refreshAccessToken } from "./FetcherWithJWT";
 
 const TEST_MODE = import.meta.env.VITE_TEST_MODE;
 const USER_BACKEND_URL = import.meta.env.VITE_DATABASE_BACKEND_URL;
-const AUTH_BACKEND_URL = import.meta.env.VITE_EXPRESS_BACKEND_URL;
+const AUTH_BACKEND_URL = import.meta.env.VITE_AUTH_BACKEND_URL;
 const ENV = import.meta.env.VITE_ENV;
 
 /**
@@ -13,7 +13,7 @@ export async function userLogin() {
 
   // redirect users to the default page if the login appears at the home page
   if (currentLocation.pathname === "/") {
-    window.open(AUTH_BACKEND_URL + "/login", "_self");
+    window.open(AUTH_BACKEND_URL + "/auth/login", "_self");
     return;
   }
   const redirectURI = currentLocation?.pathname + currentLocation?.search;
@@ -21,7 +21,7 @@ export async function userLogin() {
 
   window.open(
     AUTH_BACKEND_URL +
-      "/login?redirect-path=" +
+      "/auth/login?redirect-path=" +
       encodeURIComponent(redirectURI),
     "_self"
   );
@@ -38,7 +38,7 @@ export async function userLogout() {
   // Log user out with redirect path
   window.open(
     AUTH_BACKEND_URL +
-      "/logout?redirect-path=" +
+      "/auth/logout?redirect-path=" +
       encodeURIComponent(redirectURI),
     "_self"
   );


### PR DESCRIPTION
Breaking change:
- Auth backend will be hosting on `domain:443/auth/` instead of `domain:8443/`
- Rename `VITE_EXPRESS_BACKEND_URL` to `VITE_AUTH_BACKEND_URL` in .env file
