### PR TITLE
Addressing workflow does not contain permissions

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/I-GUIDE/iguide-ue-frontend/security/code-scanning/1](https://github.com/I-GUIDE/iguide-ue-frontend/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job(s) that do not already have one. The most secure approach is to set the minimal permissions required for the workflow to function. If the workflow only needs to check out code and run tests, `contents: read` is usually sufficient. You can add the following block at the top level (applies to all jobs) or under the `build-and-test` job (applies only to that job). Since there is only one active job, adding it at the workflow root is simplest and future-proof.

**Steps:**
- Add the following block after the `name:` and before `on:` (e.g., after line 1):

  ```yaml
  permissions:
    contents: read
  ```

- This ensures that the `GITHUB_TOKEN` only has read access to repository contents, which is the least privilege required for most CI jobs.

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
