### PR TITLE
Addressing a validation error for trust proxy

### DIFF
--- a/cilogon/auth_server.js
+++ b/cilogon/auth_server.js
@@ -37,7 +37,7 @@ app.use(express.urlencoded({
   extended: true,
 }));
 
-app.set('trust proxy', true);
+app.set('trust proxy', 1);
 
 app.use(express.json({ limit: '15mb' }));
 app.use(session({


### PR DESCRIPTION
Fix this error `ValidationError: The Express 'trust proxy' setting is true, which allows anyone to trivially bypass IP-based rate limiting.`
