### PR TITLE
Disable caching for index.html

### DIFF
--- a/nginx-config/nginx.conf
+++ b/nginx-config/nginx.conf
@@ -19,6 +19,13 @@ server {
 		index index.html;
 		try_files $uri $uri/ /index.html;
 
+    # Disable caching for index.html
+    location = /index.html {
+      add_header Cache-Control "no-cache, no-store, must-revalidate";
+      add_header Pragma "no-cache";
+      add_header Expires 0;
+    }
+
 		include /etc/nginx/ip-list*.conf;
 	}
 


### PR DESCRIPTION
- Disabled caching for index.html to prevent outdated chunk files from being loaded.
