### PR TITLE
Fix an issue where focus is always activated on the nav bar dropdown …

### DIFF
--- a/src/components/HoverOverMenuTab.jsx
+++ b/src/components/HoverOverMenuTab.jsx
@@ -112,7 +112,6 @@ export default forwardRef(function HoverOverMenuTab(props, ref) {
                 component={RouterLink}
                 to={item[1]}
                 key={item[0]}
-                ref={(el) => (menuItemsRef.current[index] = el)}
                 onClick={() => setAnchorEl(null)}
                 onKeyDown={(e) => handleMenuKeyDown(e, index)}
               >


### PR DESCRIPTION
…menu even when using mouse

Before
<img width="229" height="279" alt="Screenshot 2025-09-06 at 6 12 40 PM" src="https://github.com/user-attachments/assets/5541d378-c4c7-48ea-bb2b-feb4539f6338" />

After
<img width="210" height="164" alt="Screenshot 2025-09-06 at 6 12 50 PM" src="https://github.com/user-attachments/assets/9695217c-cb50-4ed7-8e70-1c62e1287330" />
